### PR TITLE
Added functionality to disable automatically returning the agent

### DIFF
--- a/lib/electric_slide/agent.rb
+++ b/lib/electric_slide/agent.rb
@@ -36,6 +36,7 @@ class ElectricSlide::Agent
   end
 
   def join(queued_call)
+    logger.info "Joining the agent to #{queued_call.from}"
     # For use in queues that need bridge connections
     @call.join queued_call
   end

--- a/lib/electric_slide/agent.rb
+++ b/lib/electric_slide/agent.rb
@@ -36,7 +36,6 @@ class ElectricSlide::Agent
   end
 
   def join(queued_call)
-    logger.info "Joining the agent to #{queued_call.from}"
     # For use in queues that need bridge connections
     @call.join queued_call
   end

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -167,6 +167,7 @@ class ElectricSlide
       when :bridge
         bridge_agent agent, queued_call
       end
+      logger.info "Leaving connect method"
     end
 
     def conditionally_return_agent(agent)

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -257,6 +257,8 @@ class ElectricSlide
       # Stash caller ID to make log messages work even if calls end
       queued_caller_id = queued_call.from
 
+      logger.info "In bridge agent method"
+
       agent.call.on_unjoined do
         agent.callback :disconnect, self, agent.call, queued_call
         ignoring_ended_calls { queued_call.hangup }

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -12,6 +12,11 @@ class ElectricSlide
       :bridge,
     ].freeze
 
+    AGENT_RETURN_METHODS = [
+      :auto,
+      :manual,
+    ].freeze
+
     def self.work(*args)
       self.supervise *args
     end
@@ -19,8 +24,10 @@ class ElectricSlide
     def initialize(opts = {})
       agent_strategy   = opts[:agent_strategy]  || AgentStrategy::LongestIdle
       @connection_type = opts[:connection_type] || :call
+      @agent_return_method = opts[:agent_return_method] || :auto
 
       raise ArgumentError, "Invalid connection type; must be one of #{CONNECTION_TYPES.join ','}" unless CONNECTION_TYPES.include? @connection_type
+      raise ArgumentError, "Invalid requeue method; must be one of #{AGENT_RETURN_METHODS.join ','}" unless AGENT_RETURN_METHODS.include? @agent_return_method
 
       @free_agents = [] # Needed to keep track of waiting order
       @agents = []      # Needed to keep track of global list of agents
@@ -167,11 +174,10 @@ class ElectricSlide
       when :bridge
         bridge_agent agent, queued_call
       end
-      logger.info "Leaving connect method"
     end
 
     def conditionally_return_agent(agent)
-      if agent && @agents.include?(agent) && agent.presence == :busy
+      if agent && @agents.include?(agent) && agent.presence == :busy && @agent_return_method == :auto
         logger.info "Returning agent #{agent.id} to queue"
         return_agent agent
       else
@@ -257,13 +263,13 @@ class ElectricSlide
     def bridge_agent(agent, queued_call)
       # Stash caller ID to make log messages work even if calls end
       queued_caller_id = queued_call.from
-
-      logger.info "In bridge agent method"
+      agent.call[:queued_call] = queued_call
 
       agent.call.on_unjoined do
         agent.callback :disconnect, self, agent.call, queued_call
         ignoring_ended_calls { queued_call.hangup }
         ignoring_ended_calls { conditionally_return_agent agent if agent.call.active? }
+        agent.call[:queued_call] = nil
       end
 
       agent.call.on_end do


### PR DESCRIPTION
The agent_return_method can now be set to :manual, which will leave the agent presence in "busy" state until the return_agent method is called manually. 

This allows for additional agent states not supported b the queue, such as "wrapup".