### PR TITLE
Automatically return agent when call is dropped.

### DIFF
--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -176,8 +176,12 @@ class ElectricSlide
       end
     end
 
-    def conditionally_return_agent(agent)
-      if agent && @agents.include?(agent) && agent.presence == :busy && @agent_return_method == :auto
+    def conditionally_return_agent(agent, tmp_return_method = nil)
+      method = tmp_return_method ||= @agent_return_method
+
+      raise ArgumentError, "Invalid requeue method; must be one of #{AGENT_RETURN_METHODS.join ','}" unless AGENT_RETURN_METHODS.include? method
+
+      if agent && @agents.include?(agent) && agent.presence == :busy && method == :auto
         logger.info "Returning agent #{agent.id} to queue"
         return_agent agent
       else
@@ -283,7 +287,7 @@ class ElectricSlide
       ignoring_ended_calls do
         if agent.call.active?
           logger.info "Caller #{queued_caller_id} failed to connect to Agent #{agent.id} due to caller hangup"
-          conditionally_return_agent agent
+          conditionally_return_agent agent, :auto
         end
       end
 

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -176,12 +176,10 @@ class ElectricSlide
       end
     end
 
-    def conditionally_return_agent(agent, tmp_return_method = nil)
-      method = tmp_return_method ||= @agent_return_method
+    def conditionally_return_agent(agent, return_method = @agent_return_method)
+      raise ArgumentError, "Invalid requeue method; must be one of #{AGENT_RETURN_METHODS.join ','}" unless AGENT_RETURN_METHODS.include? return_method
 
-      raise ArgumentError, "Invalid requeue method; must be one of #{AGENT_RETURN_METHODS.join ','}" unless AGENT_RETURN_METHODS.include? method
-
-      if agent && @agents.include?(agent) && agent.presence == :busy && method == :auto
+      if agent && @agents.include?(agent) && agent.presence == :busy && return_method == :auto
         logger.info "Returning agent #{agent.id} to queue"
         return_agent agent
       else


### PR DESCRIPTION
Fixes the issue that occurs when :manual agent return method is used and the connecting call is dropped. The agent will not automatically be returned, and the application doesn't have a simple method to determine the call was dropped.