### PR TITLE
Fixed issue of agents not being returned to queue

### DIFF
--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -199,7 +199,7 @@ class ElectricSlide
       ignoring_ended_calls do
         if agent.call && agent.call.active?
           logger.warn "Dead call exception in #connect but agent call still alive, reinserting into queue"
-          return_agent queued_call
+          return_agent agent
         end
       end
     end


### PR DESCRIPTION
Copy and paste bug I assume. Returning the hungup call to the queue instead of the agent.