### PR TITLE
Added two new agent callbacks 

### DIFF
--- a/lib/electric_slide/agent.rb
+++ b/lib/electric_slide/agent.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 class ElectricSlide::Agent
-  attr_accessor :id, :address, :presence, :call, :connect_callback, :disconnect_callback
+  attr_accessor :id, :address, :presence, :call, :connect_callback, :disconnect_callback, :agent_available_callback, :connection_failed_callback
 
   # @param [Hash] opts Agent parameters
   # @option opts [String] :id The Agent's ID
@@ -28,6 +28,18 @@ class ElectricSlide::Agent
   # The block will be passed the queue, the agent call and the client call
   def self.on_disconnect(&block)
     @disconnect_callback = block
+  end
+
+  # Provide a block to be called when this agent state is set to available
+  # The block will be passed the queue, the agent call and the client call
+  def self.on_agent_available(&block)
+    @agent_available_callback = block
+  end
+
+  # Provide a block to be called when the agent connection to the callee fails
+  # The block will be passed the queue, the agent call and the client call
+  def self.on_connection_failed(&block)
+    @connection_failed_callback = block
   end
 
   # Called to provide options for calling this agent that are passed to #dial


### PR DESCRIPTION
1) connection_failed - Occurs when the agent and outbound call can't be connected for some reason, but the agent call is still alive
2) agent_available - Occurs every time the agent is added to the queue with the status available. This allows external state machines to sync to the internal agent state in electric slide.
