### PR TITLE
Added two new callbacks to the call queue.

### DIFF
--- a/lib/electric_slide/agent.rb
+++ b/lib/electric_slide/agent.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 class ElectricSlide::Agent
-  attr_accessor :id, :address, :presence, :call, :connect_callback, :disconnect_callback
+  attr_accessor :id, :address, :presence, :call, :connect_callback, :disconnect_callback, :status_changed_callback, :connection_failed_callback
 
   # @param [Hash] opts Agent parameters
   # @option opts [String] :id The Agent's ID
@@ -28,6 +28,18 @@ class ElectricSlide::Agent
   # The block will be passed the queue, the agent call and the client call
   def self.on_disconnect(&block)
     @disconnect_callback = block
+  end
+
+  # Provide a block to be called when this agent state is set to available
+  # The block will be passed the queue, the agent call and the client call
+  def self.on_status_changed(&block)
+    @status_changed_callback = block
+  end
+
+  # Provide a block to be called when the agent connection to the callee fails
+  # The block will be passed the queue, the agent call and the client call
+  def self.on_connection_failed(&block)
+    @connection_failed_callback = block
   end
 
   # Called to provide options for calling this agent that are passed to #dial


### PR DESCRIPTION
connection_failed callback - When agent cannot join to call, due to the call ending or another error. Requires agent call to still be active if using bridging mode.

status_changed callback - fires whenever the agents presence changes. Will send back call_queue, agent_call, agent_status as parameters to the callback block. Useful to transition other state machines on ES events.
