### PR TITLE
Keep track of unavailable agents

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -63,7 +63,7 @@ end
 Adding an Agent to the Queue
 ----------------------------
 
-ElectricSlide expects to be given a objects that quack like an agent. You can use the built-in `ElectricSlide::Agent` class, or you can provide your own.
+ElectricSlide expects to be instances of the `ElectricSlide::Agent` class. This is designed to be extended with custom functionality when necessary.
 
 To add an agent who will receive calls whenever a call is enqueued, do something like this:
 
@@ -72,7 +72,7 @@ agent = ElectricSlide::Agent.new id: 1, address: 'sip:agent1@example.com', prese
 ElectricSlide.get_queue(:my_queue).add_agent agent
 ```
 
-To inform the queue that the agent is no longer available you *must* use the ElectricSlide queue interface. /Do not attempt to alter agent objects directly!/
+To inform the queue that the agent is no longer available you *must* use the ElectricSlide queue interface. **_Do not attempt to change agent objects directly!_**
 
 ```ruby
 ElectricSlide.update_agent 1, presence: offline
@@ -84,17 +84,20 @@ If it is more convenient, you may also pass `#update_agent` an Agent-like object
 options = {
   id: 1,
   address: 'sip:agent1@example.com',
-  presence: offline
+  presence: :unavailable
 }
 agent = ElectricSlide::Agent.new options
 ElectricSlide.update_agent 1, agent
 ```
 
-The possible presence states an Agent may be in are:
+The possible presence states for an Agent are:
 
 * `:available` - Waiting for a call
 * `:on_call` - Currently connected to a call
 * `:after_call` - In a quiet period after completing a call and before being made available again. This is only encountered with a manual agent return strategy.
+* `:unavailable` - Agent is not available (on break, offline, etc)
+
+Note that an `:unavailable` agent still counts as an agent in the queue, but will not be sent any calls. Make sure to remove agents, even unavailable ones, when agents sign out by using the `#remove_agent` method.
 
 Switching connection types
 --------------------------

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -64,8 +64,10 @@ class ElectricSlide
     # @return {Agent}
     def checkout_agent
       agent = @strategy.checkout_agent
-      agent.presence = :on_call if agent
-      agent.callback :presence_change, self, agent.call, agent.presence
+      if agent
+        agent.presence = :on_call
+        agent.callback :presence_change, self, agent.call, agent.presence
+      end
       agent
     end
 

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -106,9 +106,12 @@ class ElectricSlide
         ensure_bridged_agent_call_alive agent
 
         unless agent.call[:electric_slide_callback_set]
-          queue = self
           agent.call[:electric_slide_callback_set] = true
-          agent.call.on_end { queue.return_agent agent, :unavailable }
+          queue = self
+          agent.call.on_end do
+            agent.call = nil
+            queue.return_agent agent, :unavailable
+          end
         end
       end
 

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -206,7 +206,7 @@ class ElectricSlide
       when :call
         call_agent agent, queued_call
       when :bridge
-        unless agent.call.active?
+        unless agent.call && agent.call.active?
           logger.warn "Inactive agent call found in #connect, returning caller to queue"
           priority_enqueue queued_call
         end
@@ -341,7 +341,7 @@ class ElectricSlide
       agent.call.register_tmp_handler :event, Punchblock::Event::Unjoined do
         agent.callback :disconnect, self, agent.call, queued_call
         ignoring_ended_calls { queued_call.hangup }
-        ignoring_ended_calls { conditionally_return_agent agent if agent.call.active? }
+        ignoring_ended_calls { conditionally_return_agent agent if agent.call && agent.call.active? }
         agent.call[:queued_call] = nil
       end
 
@@ -354,7 +354,7 @@ class ElectricSlide
       agent.join queued_call if queued_call.active?
     rescue *ENDED_CALL_EXCEPTIONS
       ignoring_ended_calls do
-        if agent.call.active?
+        if agent.call && agent.call.active?
           agent.callback :connection_failed, self, agent.call, queued_call
 
           logger.info "Caller #{queued_caller_id} failed to connect to Agent #{agent.id} due to caller hangup"

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -353,6 +353,10 @@ class ElectricSlide
         agent.call[:queued_call] = nil
       end
 
+      queued_call.register_tmp_handler :event, Punchblock::Event::Joined do |event|
+        queued_call[:electric_slide_connected_at] = event.timestamp
+      end
+
       agent.callback :connect, self, agent.call, queued_call
 
       agent.join queued_call if queued_call.active?

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -309,7 +309,7 @@ class ElectricSlide
 
       # Track whether the agent actually talks to the queued_call
       connected = false
-      queued_call.on_joined do |event|
+      queued_call.register_tmp_handler :event, Punchblock::Event::Joined do |event|
         connected = true
         queued_call[:electric_slide_connected_at] = event.timestamp
       end

--- a/spec/electric_slide/call_queue_spec.rb
+++ b/spec/electric_slide/call_queue_spec.rb
@@ -58,23 +58,23 @@ describe ElectricSlide::CallQueue do
     let(:agent) { ElectricSlide::Agent.new id: agent_id, address: '123', presence: :available }
     let!(:agent_call) { Adhearsion::OutboundCall.new }
     let(:queued_call) { dummy_call }
+    let(:connected_time) { DateTime.now }
 
     before do
-      queue.add_agent agent
+      allow(Adhearsion::OutboundCall).to receive(:new) { agent_call }
+      allow(agent).to receive(:dial_options_for) {
+        { confirm: double('ConfirmController') }
+      }
+
+      allow(queued_call).to receive(:active?) { true }
     end
 
     context "with connection type :call" do
       let(:connection_type) { :call }
-      let(:connected_time) { DateTime.now }
 
       before do
-        allow(Adhearsion::OutboundCall).to receive(:new) { agent_call }
-        allow(agent).to receive(:dial_options_for) {
-          { confirm: double('ConfirmController') }
-        }
-
-        allow(queued_call).to receive(:active?) { true }
         allow(agent_call).to receive(:dial)
+        queue.add_agent agent
         queue.connect(queue.checkout_agent, queued_call)
         queued_call << Punchblock::Event::Joined.new(timestamp: connected_time)
       end
@@ -124,12 +124,77 @@ describe ElectricSlide::CallQueue do
       end
     end
 
-    context "with connection type :bridge"
+    context "with connection type :bridge" do
+      let(:connection_type) { :bridge }
+
+      before do
+        allow(agent_call).to receive(:active?) { true }
+        allow(queued_call).to receive(:hangup) { true }
+        agent.call = agent_call
+        queue.add_agent agent
+
+        allow(agent_call).to receive(:join) do
+          agent_call << Punchblock::Event::Joined.new(timestamp: connected_time)
+          queued_call << Punchblock::Event::Joined.new(timestamp: connected_time)
+        end
+        queue.enqueue queued_call
+      end
+
+      it "records the connection time in the :electric_slide_connected_at call variable on the queued call" do
+        expect(queued_call[:electric_slide_connected_at]).to eq(connected_time)
+      end
+
+      context 'when the call ends' do
+        it "unsets the agent's `call` attribute" do
+          expect {
+            agent_call << Punchblock::Event::End.new(reason: :hangup)
+          }.to change(agent, :call).from(agent_call).to(nil)
+        end
+
+        it "marks the agent :unavailable" do
+          expect {
+            agent_call << Punchblock::Event::End.new(reason: :hangup)
+          }.to change(agent, :presence).from(:on_call).to(:unavailable)
+        end
+
+        context "when the return strategy is :auto" do
+          let(:agent_return_method) { :auto }
+
+          it "makes the agent available for a call" do
+            agent_call << Punchblock::Event::Unjoined.new
+            expect(queue.checkout_agent).to eql(agent)
+          end
+
+          it "sets the agent's presence to :available" do
+            agent_call << Punchblock::Event::Unjoined.new
+            expect(queue.get_agent(agent.id).presence).to eql(:available)
+          end
+        end
+
+        context "when the return strategy is :manual" do
+          let(:agent_return_method) { :manual }
+
+          it "does not make the agent available for a call" do
+            agent_call << Punchblock::Event::Unjoined.new
+            expect(queue.checkout_agent).to eql(nil)
+          end
+
+          it "sets the agent's presence to :after_call" do
+            agent_call << Punchblock::Event::Unjoined.new
+            expect(queue.get_agent(agent.id).presence).to eql(:after_call)
+          end
+        end
+      end
+    end
   end
 
   describe '#add_agent' do
     let(:queue) { ElectricSlide::CallQueue.new }
     let(:agent) { ElectricSlide::Agent.new(id: '1', address: 'agent@example.com') }
+
+    before do
+      allow(agent).to receive(:call) { Adhearsion::OutboundCall.new }
+    end
 
     it "associates the agent with in the queue" do
       expect {
@@ -161,6 +226,10 @@ describe ElectricSlide::CallQueue do
   describe '#return_agent' do
     let(:queue) { ElectricSlide::CallQueue.new }
     let(:agent) { ElectricSlide::Agent.new(id: '1', address: 'agent@example.com', presence: :on_call) }
+
+    before do
+      allow(agent).to receive(:call) { Adhearsion::OutboundCall.new }
+    end
 
     context 'when the agent is a member of the queue' do
       before do


### PR DESCRIPTION
This allows queues to track agents that are offline, which is helpful (for example) in bridge mode while agents are being called. Without this, an application would have to keep a separate registry of agents dialing in, which could result in race conditions.