### PR TITLE
Cleaner supervision/registry for queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * API Breakage: Queues must now be Celluloid actors responding to the standard actor API. `ElectricSlide::CallQueue.work` is removed in favour of `.new`.
   * API Breakage: Prevent an unqueued agent from being returned to the queue - this avoids calls after logging out
   * API Breakage: An agent's presence should be :after_call if they are not automatically returned to being available
   * API Breakage: Store queued/connected timestamps on calls

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -30,12 +30,8 @@ class ElectricSlide
 
     attr_reader :agent_strategy, :connection_type, :agent_return_method
 
-    def self.work(*args)
-      self.supervise *args
-    end
-
     def initialize(opts = {})
-      @agent_strategy   = opts[:agent_strategy]  || AgentStrategy::LongestIdle
+      @agent_strategy  = opts[:agent_strategy]  || AgentStrategy::LongestIdle
       @connection_type = opts[:connection_type] || :call
       @agent_return_method = opts[:agent_return_method] || :auto
 


### PR DESCRIPTION
Reduce complexity by using a single supervisor for all queues, which now must all be actors. CallQueue.work is no longer implemented, and queues must follow the standard Celluloid Actor API.