### PR TITLE
Adding support for queue class pre-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * Provide Electric Slide with a way to check if a queue with a given set of attributes is valid/can be instantiated before Electric Slide adds it to the supervision group. The supervisor will crash if its attempt to create the queue raises an exception.
   * Add support for changing queue attributes
     * API Breakage: Setting queue connection type to an invalid value will now raise an `ElectricSlide::CallQueue::InvalidConnectionType` exception instead of `ArgumentError`
     * API Breakage: Setting queue agent return method to an invalid value will now raise an `ElectricSlide::CallQueue::InvalidRequeueMethod` exception instead of `ArgumentError`

--- a/lib/electric_slide.rb
+++ b/lib/electric_slide.rb
@@ -43,8 +43,12 @@ class ElectricSlide
 
   def self.create(name, queue_class = nil, *args)
     fail "Queue with name #{name} already exists!" if get_queue(name)
-    @supervisor.supervise_as name, (queue_class || CallQueue), *args
-    get_queue name
+
+    queue_class ||= CallQueue
+    if !queue_class.respond_to?(:valid_with?) || queue_class.valid_with?(*args)
+      @supervisor.supervise_as name, (queue_class || CallQueue), *args
+      get_queue name
+    end
   end
 
   def self.get_queue!(name)

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -44,6 +44,34 @@ class ElectricSlide
 
     attr_reader :agent_strategy, :connection_type, :agent_return_method
 
+    def self.valid_with?(attrs = {})
+      return false unless Hash === attrs
+
+      if agent_strategy = attrs[:agent_strategy]
+        begin
+          agent_strategy.new
+        rescue Exception
+          return false
+        end
+      end
+      if connection_type = attrs[:connection_type]
+        return false unless valid_connection_type? connection_type
+      end
+      if agent_return_method = attrs[:agent_return_method]
+        return false unless valid_agent_return_method? agent_return_method
+      end
+
+      true
+    end
+
+    def self.valid_connection_type?(connection_type)
+      CONNECTION_TYPES.include? connection_type
+    end
+
+    def self.valid_agent_return_method?(agent_return_method)
+      AGENT_RETURN_METHODS.include? agent_return_method
+    end
+
     def initialize(opts = {})
       @agents = []      # Needed to keep track of global list of agents
       @queue = []       # Calls waiting for an agent
@@ -74,12 +102,12 @@ class ElectricSlide
     end
 
     def connection_type=(new_connection_type)
-      raise InvalidConnectionType unless CONNECTION_TYPES.include? new_connection_type
+      abort InvalidConnectionType.new unless CallQueue.valid_connection_type? new_connection_type
       @connection_type = new_connection_type
     end
 
     def agent_return_method=(new_agent_return_method)
-      raise InvalidRequeueMethod unless AGENT_RETURN_METHODS.include? new_agent_return_method
+      abort InvalidRequeueMethod.new unless CallQueue.valid_agent_return_method? new_agent_return_method
       @agent_return_method = new_agent_return_method
     end
 


### PR DESCRIPTION
Provides Electric Slide with a way to check if a queue can be created
before it is started. A `::valid_with?` class method, which is given a
set of queue attributes, is implemented in `ElectricSlide::CallQueue`.