### PR TITLE
Fixing `NameError` in injected `Adhearsion::Call#active?` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * Bugfix: Fix `NameError` exception when referencing namespaced constant `Adhearsion::Call::ExpiredError` in injected `Adhearsion::Call#active?` method
   * Provide Electric Slide with a way to check if a queue with a given set of attributes is valid/can be instantiated before Electric Slide adds it to the supervision group. The supervisor will crash if its attempt to create the queue raises an exception.
   * Add support for changing queue attributes
     * API Breakage: Setting queue connection type to an invalid value will now raise an `ElectricSlide::CallQueue::InvalidConnectionType` exception instead of `ArgumentError`

--- a/lib/electric_slide.rb
+++ b/lib/electric_slide.rb
@@ -6,11 +6,13 @@ require 'adhearsion/version'
 if Gem::Version.new(Adhearsion::VERSION) < Gem::Version.new('3.0.0')
   # Backport https://github.com/adhearsion/adhearsion/commit/8c6855612c70dd822fb4e4c2006d1fdc9d05fe23 to avoid confusion around dead calls
   require 'adhearsion/call'
-  class Adhearsion::Call::ActorProxy < Celluloid::ActorProxy
-    def active?
-      alive? && super
-    rescue Adhearsion::Call::ExpiredError
-      false
+  class Adhearsion::Call
+    class ActorProxy
+      def active?
+        alive? && super
+      rescue ExpiredError
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
When an exception is raised in the backported
`Adhearsion::Call::ActorProxy#active?` method, the `rescue` clause
referencing `Adhearsion::Call::ExpiredError` constant raises a
`NameError` exception because it tries to resolve the `Adhearsion`
constant within the `Adhearsion::Call::ActorProxy` namespace, which
doesn't know about `Adhearsion`.

This fix scopes the method injection within the `Adhearsion::Call`
module namespace, which should recognize the `ExpiredError` name.