### PR TITLE
Allowing `#add_agent` to finish without waiting to establish connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * `ElectricSlide::CallQueue#add_agent` will no longer wait for a connection attempt to complete before returning
   * Trigger an agent "presence change" callback when the agent is removed from the queue
   * Bugfix: Fix `NameError` exception when referencing namespaced constant `Adhearsion::Call::ExpiredError` in injected `Adhearsion::Call#active?` method
   * Provide Electric Slide with a way to check if a queue with a given set of attributes is valid/can be instantiated before Electric Slide adds it to the supervision group. The supervisor will crash if its attempt to create the queue raises an exception.

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -179,7 +179,7 @@ class ElectricSlide
       # Fake the presence callback since this is a new agent
       agent.callback :presence_change, self, agent.call, agent.presence, :unavailable
 
-      check_for_connections
+      async.check_for_connections
     end
 
     # Marks an agent as available to take a call. To be called after an agent completes a call

--- a/spec/electric_slide/call_queue_spec.rb
+++ b/spec/electric_slide/call_queue_spec.rb
@@ -264,7 +264,15 @@ describe ElectricSlide::CallQueue do
       }.to change(queue, :checkout_agent).from(nil).to(agent)
     end
 
-    it "connects the agent to waiting queued calls"
+    it "connects the agent to waiting queued calls" do
+      call = Adhearsion::OutboundCall.new
+      queue.enqueue call
+
+      queue.add_agent agent
+      sleep 0.5
+      expect(agent.presence).to eq(:on_call)
+      expect(call[:agent]).to eq(agent)
+    end
 
     context 'when given an agent already in the queue' do
       before do


### PR DESCRIPTION
Once `ElectricSlide::CallQueue#add_agent` is done preparing and adding
the agent into the queue, it immediately checks if the agent can be
connected to a waiting call before returning.

This commit changes that behavior by returning from `#add_agent`
immediately after the agent is processed into the queue. The connection
attempt is still requested, but asynchronously.