### PR TITLE
One should not hand out an Actor's internal reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * Bugfix: Don't hand out internal CallQueue references to Agents - thread-safety
 
 # [0.4.0](https://github.com/adhearsion/electric_slide/compare/v0.3.0...v0.4.0) - [2015-12-17](https://rubygems.org/gems/adhearsion/versions/0.4.0)
   * Change `ElectricSlide::Agent` `#presence=` method name to `#update_presence`. It will also accept one more parameter called `extra_params`, a hash that holds application specific parameters that are passed to the presence change callback.


### PR DESCRIPTION
This makes it impossible to set timers on the queue from Agent callbacks, and is generally not thread-safe.