### PR TITLE
Sort priorities on FixedPriority Strategy.

### DIFF
--- a/lib/electric_slide/agent_strategy/fixed_priority.rb
+++ b/lib/electric_slide/agent_strategy/fixed_priority.rb
@@ -30,7 +30,8 @@ class ElectricSlide
       end
 
       def checkout_agent
-        _, agents = @priorities.detect do |priority, agents|
+        priorities = @priorities.sort.to_h
+        _, agents = priorities.detect do |priority, agents|
           agents.present?
         end
         agents.shift

--- a/spec/electric_slide/agent_strategy/fixed_priority_spec.rb
+++ b/spec/electric_slide/agent_strategy/fixed_priority_spec.rb
@@ -23,9 +23,9 @@ describe ElectricSlide::AgentStrategy::FixedPriority do
     agent1 = OpenStruct.new({ id: 101, priority: 2 })
     agent2 = OpenStruct.new({ id: 102, priority: 2 })
     agent3 = OpenStruct.new({ id: 103, priority: 3 })
+    subject << agent3
     subject << agent1
     subject << agent2
-    subject << agent3
     expect(subject.checkout_agent).to eql(agent1)
     expect(subject.checkout_agent).to eql(agent2)
     expect(subject.checkout_agent).to eql(agent3)


### PR DESCRIPTION
FixedPriority returns the most priority agent.