### PR TITLE
Fail gracefully if the queued_call is nil

### DIFF
--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -291,6 +291,7 @@ class ElectricSlide
       unless queued_call && queued_call.active?
         logger.warn "Inactive queued call found in #connect"
         return_agent agent
+        return
       end
 
       queued_call[:agent] = agent


### PR DESCRIPTION
Previous commit seemed to only fix some of the issue as it returns the agent but didn't stop execution.  This was tested with 50 agents 2000 matters and appears good to go.