### PR TITLE
nil calls causing agents to become stranded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/electric_slide)
+  * Bugfix: Prevent nil objects in the call queue from crashing on connection
   * Added `ElectricSlide::CallQueue#update_agent` to safely update a queued agent object's attributes
   * Added `ElectricSlide::Agent#update` to update an agent object's attributes
   * Added `ElectricSlide::Agent#callable?` to check if an agent can be called

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -241,6 +241,8 @@ class ElectricSlide
     # Checks to see if any callers are waiting for an agent and attempts to connect them to
     # an available agent
     def check_for_connections
+      # Ensure there are no nil objects in the call queue before trying to connect
+      @queue.compact!
       connect checkout_agent, get_next_caller while call_waiting? && agent_available?
     end
 
@@ -290,6 +292,8 @@ class ElectricSlide
     def connect(agent, queued_call)
       unless queued_call && queued_call.active?
         logger.warn "Inactive queued call found in #connect"
+        agent.callback :connection_failed, current_actor, agent.call, queued_call 
+
         return_agent agent
         return
       end


### PR DESCRIPTION
As no callback was fired when a nil object was passed to the `connect` method, agents where not aware that their status had become `:on_call` and thus could not take the correct action.

Two changes  were made.
1) Ensure the callback is sent on connection failure.
2) Remove all nil objects from the queue before trying to connect agents and callees.