### PR TITLE
[YNGJ-1089] Skip hanging up on queued call when transfer-specific call variable present

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -163,6 +163,12 @@ call.join metadata[:caller] if confirm!
 
 where `confirm!` is your logic for deciding if you want the call to be connected or not. Hanging up during the confirmation controller or letting it finish without any action will result in the call being sent to the next agent.
 
+Call Variables
+--------------
+
+There are special behaviors when specific variables exist on calls:
+* `electric_slide_transferring_to` - when containing a truthy value, the queued call is preserved instead of being hung up on when an agent call is unjoined; this is particularly useful for transferring calls, where you want to keep the queued call alive so that it can be enqueued somewhere else and have the agent call hang up
+
 Credits
 -------
 

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -391,8 +391,12 @@ class ElectricSlide
         ignoring_ended_calls { agent_call.hangup }
 
         ignoring_ended_calls do
-          queued_call.hangup if queued_call[:electric_slide_transferring_to].blank?
-          queued_call[:electric_slide_transferring_to] = nil
+          if queued_call[:electric_slide_transferring_to].present?
+            logger.info "Skipping hangup on Call #{queued_call.id} due to transfer to #{queued_call[:electric_slide_transferring_to]}"
+            queued_call[:electric_slide_transferring_to] = nil
+          else
+            queued_call.hangup
+          end
         end
       end
 

--- a/lib/electric_slide/call_queue.rb
+++ b/lib/electric_slide/call_queue.rb
@@ -388,8 +388,12 @@ class ElectricSlide
       queued_call.on_end { ignoring_ended_calls { agent_call.hangup } }
 
       agent_call.on_unjoined do
-       ignoring_ended_calls { agent_call.hangup }
-       ignoring_ended_calls { queued_call.hangup }
+        ignoring_ended_calls { agent_call.hangup }
+
+        ignoring_ended_calls do
+          queued_call.hangup if queued_call[:electric_slide_transferring_to].blank?
+          queued_call[:electric_slide_transferring_to] = nil
+        end
       end
 
       # Track whether the agent actually talks to the queued_call
@@ -403,7 +407,7 @@ class ElectricSlide
         # Ensure we don't return an agent that was removed or paused
         old_call = agent.call
         conditionally_return_agent agent
-        agent.call = nil if agent_return_method == :manual || agent.call == old_call 
+        agent.call = nil if agent_return_method == :manual || agent.call == old_call
 
         agent.callback :disconnect, queue, agent_call, queued_call
 


### PR DESCRIPTION
@benlangfeld @bklang

These changes skip hanging up on the queued call whenever a transfer-specific call variable is present.

We've been running this in production for some time and are looking to merge these changes upstream.